### PR TITLE
pyznap compression

### DIFF
--- a/pyznap/pyzfs.py
+++ b/pyznap/pyzfs.py
@@ -300,7 +300,10 @@ class ZFSSnapshot(ZFSDataset):
 
         # cmd.append('-v')
         # cmd.append('-P')
-
+        
+        # compression of the stream if possible
+        cmd.append('-c')
+        
         if replicate:
             cmd.append('-R')
         if properties:


### PR DESCRIPTION
add the -c flag to send;

compres the stream https://github.com/yboetz/pyznap/issues/23

If both ends have different compression this would fail and just decompress after all;