### PR TITLE
Add -v to zfs send, so that it includes stream size on FreeBSD

### DIFF
--- a/pyznap/pyzfs.py
+++ b/pyznap/pyzfs.py
@@ -323,7 +323,7 @@ class ZFSSnapshot(ZFSDataset):
         if self.ssh:
             raise NotImplementedError()
 
-        cmd = ['zfs', 'send', '-nP']
+        cmd = ['zfs', 'send', '-nPv']
 
         if base is not None:
             cmd.append('-I')


### PR DESCRIPTION
On FreeBSD 11.3, `zfs send -nP` does not show size information unless `-v` is also included.

Fixes #35 
