### PR TITLE
Gate configparser requirement to Python versions 3.6 and lower.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -35,8 +35,9 @@ setup(
     license='GPLv3',
     packages=['pyznap'],
     include_package_data=True,
+    # Python 3.7 includes configparser, but is available as a backport for 3.6 and lower.
     install_requires=[
-        'configparser>=3.5.0',
+        'configparser>=3.5.0;python_version<="3.6"',
     ],
     extras_require={
         'dev': [


### PR DESCRIPTION
Thanks to @eli-schwartz in #archlinux-aur for the suggestion, it looks like the `setup.py` can just gate the requirement. Since Arch uses Python 3.7, I know it doesn't need it for that so I've picked 3.6 as the threshold. But 3.5 might be more appropriate, hopefully you have more context.

Fixes issue #37.

Results in something like the below in `requires.txt`:
```
[:python_version <= "3.6"]
configparser>=3.5.0
```