### PR TITLE
Allow configuring the date and time formatting used in snapshot names

### DIFF
--- a/pyznap/take.py
+++ b/pyznap/take.py
@@ -17,7 +17,7 @@ import pyznap.pyzfs as zfs
 from .process import DatasetBusyError, DatasetNotFoundError, DatasetExistsError
 
 
-def take_snap(filesystem, _type):
+def take_snap(filesystem, datetime_format, _type):
     """Takes a snapshot of type '_type'
 
     Parameters
@@ -31,7 +31,7 @@ def take_snap(filesystem, _type):
     logger = logging.getLogger(__name__)
     now = datetime.now
 
-    snapname = lambda _type: 'pyznap_{:s}_{:s}'.format(now().strftime('%Y-%m-%d_%H:%M:%S'), _type)
+    snapname = lambda _type: 'pyznap_{:s}_{:s}'.format(now().strftime(datetime_format), _type)
 
     logger.info('Taking snapshot {}@{:s}...'.format(filesystem, snapname(_type)))
     try:
@@ -62,6 +62,10 @@ def take_filesystem(filesystem, conf):
     logger.debug('Taking snapshots on {}...'.format(filesystem))
     now = datetime.now
 
+    date_format = conf.get('date_format', '%Y-%m-%d')
+    time_format = conf.get('time_format', '%H:%M:%S')
+    datetime_format = '{:s}_{:s}'.format(date_format, time_format)
+
     snapshots = {'frequent': [], 'hourly': [], 'daily': [], 'weekly': [], 'monthly': [], 'yearly': []}
     for snap in filesystem.snapshots():
         # Ignore snapshots not taken with pyznap or sanoid
@@ -69,7 +73,7 @@ def take_filesystem(filesystem, conf):
             continue
         try:
             _date, _time, snap_type = snap.name.split('_')[-3:]
-            snap_time =  datetime.strptime('{:s}_{:s}'.format(_date, _time), '%Y-%m-%d_%H:%M:%S')
+            snap_time =  datetime.strptime('{:s}_{:s}'.format(_date, _time), datetime_format)
             snapshots[snap_type].append((snap, snap_time))
         except (ValueError, KeyError):
             continue
@@ -80,32 +84,32 @@ def take_filesystem(filesystem, conf):
 
     if conf['yearly'] and (not snapshots['yearly'] or
                            snapshots['yearly'][0][1].year != now().year):
-        take_snap(filesystem, 'yearly')
+        take_snap(filesystem, datetime_format, 'yearly')
 
     if conf['monthly'] and (not snapshots['monthly'] or
                             snapshots['monthly'][0][1].month != now().month or
                             now() - snapshots['monthly'][0][1] > timedelta(days=31)):
-        take_snap(filesystem, 'monthly')
+        take_snap(filesystem, datetime_format, 'monthly')
 
     if conf['weekly'] and (not snapshots['weekly'] or
                            snapshots['weekly'][0][1].isocalendar()[1] != now().isocalendar()[1] or
                            now() - snapshots['weekly'][0][1] > timedelta(days=7)):
-        take_snap(filesystem, 'weekly')
+        take_snap(filesystem, datetime_format, 'weekly')
 
     if conf['daily'] and (not snapshots['daily'] or
                           snapshots['daily'][0][1].day != now().day or
                           now() - snapshots['daily'][0][1] > timedelta(days=1)):
-        take_snap(filesystem, 'daily')
+        take_snap(filesystem, datetime_format, 'daily')
 
     if conf['hourly'] and (not snapshots['hourly'] or
                            snapshots['hourly'][0][1].hour != now().hour or
                            now() - snapshots['hourly'][0][1] > timedelta(hours=1)):
-        take_snap(filesystem, 'hourly')
+        take_snap(filesystem, datetime_format, 'hourly')
 
     if conf['frequent'] and (not snapshots['frequent'] or
                              snapshots['frequent'][0][1].minute != now().minute or
                              now() - snapshots['frequent'][0][1] > timedelta(minutes=1)):
-        take_snap(filesystem, 'frequent')
+        take_snap(filesystem, datetime_format, 'frequent')
 
 
 def take_config(config):

--- a/pyznap/utils.py
+++ b/pyznap/utils.py
@@ -91,7 +91,7 @@ def read_config(path):
 
     config = []
     options = ['key', 'frequent', 'hourly', 'daily', 'weekly', 'monthly', 'yearly', 'snap', 'clean',
-               'dest', 'dest_keys', 'compress']
+               'dest', 'dest_keys', 'compress', 'date_format', 'time_format']
 
     for section in parser.sections():
         dic = {}
@@ -115,6 +115,8 @@ def read_config(path):
                 elif option in ['dest_keys']:
                     dic[option] = [i.strip() if os.path.isfile(i.strip()) else None
                                    for i in value.split(',')]
+                elif option in ['date_format', 'time_format']:
+                    dic[option] = value.strip()
     # Pass through values recursively
     for parent in config:
         for child in config:
@@ -123,7 +125,7 @@ def read_config(path):
             child_parent = '/'.join(child['name'].split('/')[:-1])  # get parent of child filesystem
             if child_parent.startswith(parent['name']):
                 for option in ['key', 'frequent', 'hourly', 'daily', 'weekly', 'monthly', 'yearly',
-                               'snap', 'clean']:
+                               'snap', 'clean', 'date_format', 'time_format']:
                     child[option] = child[option] if child[option] is not None else parent[option]
     # Sort by pathname
     config = sorted(config, key=lambda entry: entry['name'].split('/'))


### PR DESCRIPTION
Two new, optional parameters in the configuration file `date_format` and `time_format` allow you to override the default `strftime()` values of `%Y-%m-%d` and `%H:%M:%S` respectively. This change may be really helpful if you want to expose snapshots over the network. Samba will "mangle" the names of files or directories containing the "`:`" character, as many operating systems do not allow it (in fact, Mac OS won't even show a directory containing a colon character).

Note that the change is not "backwards compatible". Date and time formatting is part of `pyznap`'s snapshot management code, so it will ignore snapshots taken with a different formatting.