### PR TITLE
Allow inline comments in configuration file

### DIFF
--- a/pyznap/utils.py
+++ b/pyznap/utils.py
@@ -76,7 +76,7 @@ def read_config(path):
         logger.error('Error while loading config: File {:s} does not exist.'.format(path))
         return None
 
-    parser = ConfigParser()
+    parser = ConfigParser(inline_comment_prefixes="#")
     try:
         parser.read(path)
     except (MissingSectionHeaderError, DuplicateSectionError, DuplicateOptionError) as e:


### PR DESCRIPTION
Cherry picked from #82.

1) So discussion and review is on a per feature basis
2) I see this as a really good QoL change
  - I don't see why any value would have a `#` sign
3) smaller PR, easier to review
4) due to cherry-pick will not break original PR