### PR TITLE
Do not snapshot child filesystem if it has a more specific config

### DIFF
--- a/pyznap/utils.py
+++ b/pyznap/utils.py
@@ -11,6 +11,7 @@
 import os
 import re
 import logging
+import pathlib
 from subprocess import Popen, PIPE, TimeoutExpired, CalledProcessError
 from .process import run
 from .ssh import SSHException
@@ -18,7 +19,6 @@ from .ssh import SSHException
 from datetime import datetime
 from configparser import (ConfigParser, NoOptionError, MissingSectionHeaderError,
                           DuplicateSectionError, DuplicateOptionError)
-from pkg_resources import resource_string
 
 
 def exists(executable='', ssh=None):
@@ -171,7 +171,10 @@ def create_config(path):
     logger = logging.getLogger(__name__)
 
     CONFIG_FILE = os.path.join(path, 'pyznap.conf')
-    config = resource_string(__name__, 'config/pyznap.conf').decode("utf-8")
+
+    config_path = (pathlib.Path(__file__).parent.resolve() / 'config' / 'pyznap.conf').absolute()
+    with open(config_path, 'r') as file:
+        config = file.read()
 
     logger.info('Initial setup...')
 


### PR DESCRIPTION
## Issue

Currently, pyznap triggers a snapshot for all children datasets based on the parent config. However, the way this is implemented can cause multiple issues when we want specific children datasets to have different snapshot settings.

This PR fixes this issue, by forgoing snapshots of children datasets when there is a more specific config targeting them.

## Example 1: Disabling snapshots for specific children

Imagine we have a ZFS file system named `rpool` with many children which we want to snapshot, but one called `rpool/swap` we don't want to snapshot at all.

Per the documentation, we would expect the following to work:

```ini
[rpool]
# ... other settings here ...
snap = yes

[rpool/swap]
snap = no
```

However, this does not work. Upon seeing the `rpool` config, pyznap will trigger a snapshot of all child filesystems regardless of whether they have a more specific config. Because the `rpool` config has `snap = yes`, this means that `rpool/swap` would be snapshotted.

With this PR, this case works as expected, and `rpool/swap` is not snapshotted.

## Example 2: Turning off specific types of snapshots for specific children

Image we have a ZFS filesystem named `rpool` with many children for which we want to keep 3 monthly snapshots.
However, for one of the children `rpool/some-dataset`, we do not wish to take monthly snapshots at all.

Per the documentation, we would expect the following to work:

```ini
[rpool]
# ... other settings here ...
monthly = 3

[rpool/some-dataset]
monthly = 0
```

However, this does not work. Upon seeing the `rpool` config, pyznap will trigger a snapshot of all child filesystems regardless of whether they have a more specific config. Because the `rpool` config has a non-zero `monthly` setting, this would trigger a monthly snapshot.

Interestingly, if `clean = yes` for `rpool/some-dataset`, this snapshot would be taken and then immediately cleaned up!

With this PR, this case works as expected, and `rpool/some-dataset` will not have monthly snapshots taken.