### PR TITLE
Add config option recursive=yes|no for each target

### DIFF
--- a/pyznap/utils.py
+++ b/pyznap/utils.py
@@ -86,7 +86,7 @@ def read_config(path):
     config = []
     options = ['key', 'frequent', 'hourly', 'daily', 'weekly', 'monthly', 'yearly', 'snap', 'clean',
                'dest', 'dest_keys', 'compress', 'exclude', 'raw_send', 'resume', 'dest_auto_create',
-               'retries', 'retry_interval']
+               'retries', 'retry_interval', 'recursive']
 
     for section in parser.sections():
         dic = {}
@@ -118,6 +118,8 @@ def read_config(path):
                                    for i in value.split(',')]
                 elif option in ['retries', 'retry_interval']:
                     dic[option] = [int(i) for i in value.split(',')]
+                elif option in ['recursive']:
+                    dic[option] = {'yes': True, 'no': False}.get(value.lower(), None)
     # Pass through values recursively
     for parent in config:
         for child in config:


### PR DESCRIPTION
Add option recursive=yes|no for taking non recursive snapshots on each target.
This option has been requested in this issue: https://github.com/yboetz/pyznap/issues/6

Here is an example config on how it looks like:
[rpool/ROOT/ubuntu]
frequent = 2
hourly = 24
daily = 3
weekly = 4
monthly = 3
snap = yes
clean = yes
recursive = no

I am currently running this patch on my homelab system.